### PR TITLE
Fix storage for deployment

### DIFF
--- a/vocab/src/test/scala/commands/AddCommandTests.scala
+++ b/vocab/src/test/scala/commands/AddCommandTests.scala
@@ -1,7 +1,6 @@
 import models._
 import org.scalatest.BeforeAndAfter
 
-/*
 class AddCommandTests extends BaseCommandTests with BeforeAndAfter {
   private def readonlyStorageWords: Seq[Word] = makeStorage("words_read_only.csv", "practice_sessions_read_only.csv").getWords
 
@@ -35,4 +34,3 @@ class AddCommandTests extends BaseCommandTests with BeforeAndAfter {
     deleteFile(testAddWordsCopy)
   }
 }
-*/

--- a/vocab/src/test/scala/commands/BaseCommandTests.scala
+++ b/vocab/src/test/scala/commands/BaseCommandTests.scala
@@ -1,6 +1,7 @@
-/*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfter
+import io.github.soc.directories.ProjectDirectories
+import java.nio.file.{Files, Paths}
 import scala.util.Random
 import scala.collection.mutable.ListBuffer
 import java.io._
@@ -17,25 +18,26 @@ class BaseCommandTests extends AnyFunSuite with BeforeAndAfter {
     copyFiles foreach deleteFile
   }
 
-  val projectDir = System.getProperty("user.dir")
+  val dataDir = ProjectDirectories.from("io", "github.daltyboy11", "vocab").dataDir + "/test"
+  Files.createDirectories(Paths.get(dataDir))
   
   def makeStorage(wordFileName: String, practiceSessionFileName: String) =
-    Storage(s"${projectDir}/src/test/scala/commands", wordFileName, practiceSessionFileName)
+    Storage(dataDir + s"/$wordFileName", dataDir + s"/$practiceSessionFileName")
 
   def writeToFile(s: String, fileName: String): Unit = {
-    val file = new File(s"${projectDir}/src/test/scala/commands/$fileName")
+    val file = new File(dataDir + s"/$fileName")
     val bw = new BufferedWriter(new FileWriter(file))
     bw.write(s)
     bw.close()
   }
 
   def readFromWordFile(file: String): Seq[Word] = {
-    val fileName = s"${projectDir}/src/test/scala/commands/$file"
-    (for (line <- Source.fromFile(fileName).getLines) yield line.get[Word]).toSeq
+    val filePath = dataDir + s"/$file"
+    (for (line <- Source.fromFile(filePath).getLines) yield line.get[Word]).toSeq
   }
 
   def makeFileCopy(file: String): String = {
-    val fullyQualifiedPath = s"${projectDir}/src/test/scala/commands/$file"
+    val fullyQualifiedPath = dataDir + s"/$file"
     val destinationSuffix = Random.alphanumeric.take(10).mkString("")
     val fullyQualifiedDestination = fullyQualifiedPath + destinationSuffix
     val src = new File(fullyQualifiedPath)
@@ -45,6 +47,5 @@ class BaseCommandTests extends AnyFunSuite with BeforeAndAfter {
     file + destinationSuffix
   }
 
-  def deleteFile(file: String) = { new File(s"${projectDir}/src/test/scala/commands/$file").delete() }
+  def deleteFile(file: String) = new File(dataDir + s"/$file").delete()
 }
-*/

--- a/vocab/src/test/scala/commands/DeleteCommandTests.scala
+++ b/vocab/src/test/scala/commands/DeleteCommandTests.scala
@@ -1,7 +1,6 @@
 import org.scalatest.BeforeAndAfter
 import models._
 
-/*
 class DeleteCommandTests extends BaseCommandTests with BeforeAndAfter {
   private def readonlyStorageWords: Seq[Word] = makeStorage("test_delete_words.csv",
     "practice_sessions_read_only.csv").getWords
@@ -74,4 +73,3 @@ class DeleteCommandTests extends BaseCommandTests with BeforeAndAfter {
     }
   }
 }
-*/

--- a/vocab/src/test/scala/commands/ModifyCommandTests.scala
+++ b/vocab/src/test/scala/commands/ModifyCommandTests.scala
@@ -1,7 +1,6 @@
 import org.scalatest.BeforeAndAfter
 import models._
 
-/*
 class ModifyCommandTests extends BaseCommandTests with BeforeAndAfter {
   private def readonlyStorageWords = makeStorage("test_modify_words.csv",
     "practice_sessions_read_only.csv").getWords
@@ -46,4 +45,3 @@ class ModifyCommandTests extends BaseCommandTests with BeforeAndAfter {
     }
   }
 }
-*/

--- a/vocab/src/test/scala/commands/WordsCommandTests.scala
+++ b/vocab/src/test/scala/commands/WordsCommandTests.scala
@@ -1,6 +1,5 @@
 import models._
 
-/*
 class WordsCommandTests extends BaseCommandTests {
   test("split definition 1") {
     implicit val maxColumnWidth = 35
@@ -65,4 +64,3 @@ class WordsCommandTests extends BaseCommandTests {
     }
   }
 }
-*/

--- a/vocab/src/test/scala/commands/practice_sessions_read_only.csv
+++ b/vocab/src/test/scala/commands/practice_sessions_read_only.csv
@@ -1,4 +1,0 @@
-all,1,1,1,true
-half,1,1,1,true
-1,1,1,1,true
-0.5,1,1,1,false

--- a/vocab/src/test/scala/commands/test_add_words.csv
+++ b/vocab/src/test/scala/commands/test_add_words.csv
@@ -1,7 +1,0 @@
-ardor,enthusiasm or passion,noun,0
-irascible,easily angered,adjective,1
-rapacious,aggresively greedy or grasping,adjective,1
-risible,such as to provoke laughter,adjective,0
-peregrination,a long and meandering journey,,3
-rapine,the violent seizure of the property belonging to someone,,10
-mellifluous,sweet or musical sounding,adjective,1

--- a/vocab/src/test/scala/commands/words_read_only.csv
+++ b/vocab/src/test/scala/commands/words_read_only.csv
@@ -1,8 +1,0 @@
-ardor,enthusiasm or passion,noun,0
-irascible,easily angered,adjective,1
-rapacious,aggresively greedy or grasping,adjective,1
-risible,such as to provoke laughter,adjective,0
-peregrination,a long and meandering journey,,3
-rapine,the violent seizure of the property belonging to someone,,10
-mellifluous,sweet or musical sounding,adjective,1
-nadir,the low point of the suffering of someone,,0

--- a/vocab/src/test/scala/storage/StorageTests.scala
+++ b/vocab/src/test/scala/storage/StorageTests.scala
@@ -1,11 +1,13 @@
 import org.scalatest.funsuite.AnyFunSuite
+import java.io.{File, FileInputStream, FileOutputStream}
+import io.github.soc.directories.ProjectDirectories
 
 import models._
 import storage._
 
-/*
 class StorageTests extends AnyFunSuite {
-  val projectDir = System.getProperty("user.dir")
+
+  val dataDir = ProjectDirectories.from("io", "github.daltyboy11", "vocab").dataDir + "/test"
 
   val csv1Words = Seq(
     Word("ardor", "enthusiasm or passion", Some(Noun), 0),
@@ -24,40 +26,30 @@ class StorageTests extends AnyFunSuite {
     PracticeSession(PercentageNumeric(0.5f), 1, 1, 1, false))
 
   test("word and practice session test data successfully loads") {
-    val storage = Storage(s"${projectDir}/src/test/scala/storage",
-      "words1.csv",
-      "practice_sessions1.csv")
-
+    val storage = Storage(dataDir + "/words1.csv", dataDir + "/practice_sessions1.csv")
     assertResult(csv1Words) {
       storage.getWords
     }
-
     assertResult(csv1PracticeSessions) {
       storage.getPracticeSessions
     }
   }
 
   test("addWord succesfully inserts word") {
-   val storage = Storage(s"${projectDir}/src/test/scala/storage",
-    "words1.csv",
-    "practice_sessions1.csv")
-
-   val wordToAdd = Word("peremptory",
+    val storage = Storage(dataDir + "/words1.csv", dataDir + "/practice_sessions1.csv")
+    val wordToAdd = Word("peremptory",
       "insistion on immediate attention or obedience",
       Some(Adjective),
       0)
 
-   assertResult(csv1Words :+ wordToAdd) {
-     storage.addWord(wordToAdd)
-     storage.getWords
-   }
+    assertResult(csv1Words :+ wordToAdd) {
+      storage.addWord(wordToAdd)
+      storage.getWords
+    }
   }
 
   test("addPracticeSession succesfully inserts practice session") {
-    val storage = Storage(s"${projectDir}/src/test/scala/storage",
-    "words1.csv",
-    "practice_sessions1.csv")
-
+    val storage = Storage(dataDir + "/words1.csv", dataDir + "/practice_sessions1.csv")
     val practiceSessionToAdd = PracticeSession(All, 1, 1, 1, true)
     assertResult(csv1PracticeSessions :+ practiceSessionToAdd) {
       storage.addPracticeSession(practiceSessionToAdd)
@@ -67,11 +59,10 @@ class StorageTests extends AnyFunSuite {
 
   test("commit") {
     // Set up - create temp files
-    import java.io.{File, FileInputStream, FileOutputStream}
-    val srcWordsFile = new File( s"${projectDir}/src/test/scala/storage/words1.csv" )
-    val srcPracticeSessionsFile = new File( s"${projectDir}/src/test/scala/storage/practice_sessions1.csv" )
-    val destWordsFile = new File( s"${projectDir}/src/test/scala/storage/words2.csv" )
-    val destPracticeSessionsFile = new File( s"${projectDir}/src/test/scala/storage/practice_sessions2.csv" )
+    val srcWordsFile = new File(dataDir + "/words1.csv")
+    val srcPracticeSessionsFile = new File(dataDir + "/practice_sessions1.csv")
+    val destWordsFile = new File(dataDir + "/words2.csv")
+    val destPracticeSessionsFile = new File(dataDir + "/practice_sessions2.csv")
     (new FileOutputStream( destWordsFile ))
       .getChannel
       .transferFrom( new FileInputStream( srcWordsFile ).getChannel, 0, Long.MaxValue )
@@ -80,10 +71,7 @@ class StorageTests extends AnyFunSuite {
       .transferFrom( new FileInputStream( srcPracticeSessionsFile ).getChannel, 0, Long.MaxValue )
 
     // Test that committing will overwrite the contents of the storage files
-    val storage = Storage( s"${projectDir}/src/test/scala/storage",
-      "words2.csv",
-      "practice_sessions2.csv"
-    )
+    val storage = Storage(dataDir + "/words2.csv", dataDir + "/practice_sessions2.csv")
 
     val word1 = Word( "hoise", "to lift raise", Some( Verb ), 0 )
     val word2 = Word( "ambidextrous", "using both hands with equal dexterity", Some( Adjective ), 5 )
@@ -113,28 +101,21 @@ class StorageTests extends AnyFunSuite {
       practiceSession1)
 
     // Create a new storage with the same source files. This will be a fresh reload of the files
-    val testStorage = Storage( s"${projectDir}/src/test/scala/storage",
-      "words2.csv",
-      "practice_sessions2.csv"
-    )
+    val testStorage = Storage(dataDir + "/words2.csv", dataDir + "/practice_sessions2.csv")
 
     assertResult( expectedWords ) {
       testStorage.getWords
     }
-
     assertResult( expectedPracticeSessions ) {
       testStorage.getPracticeSessions
     }
 
-    // Tear down - destroy temp files
     destWordsFile.delete()
     destPracticeSessionsFile.delete()
   }
 
   test("increment word counts") {
-    val storage = Storage(s"${projectDir}/src/test/scala/storage",
-      "words1.csv",
-      "practice_sessions1.csv")
+    val storage = Storage(dataDir + "/words1.csv", dataDir + "/practice_sessions1.csv")
 
     val wordsToIncrement = Set(
       Word("ardor", "enthusiasm or passion", Some(Noun), 0),
@@ -154,4 +135,3 @@ class StorageTests extends AnyFunSuite {
     }
   }
 }
-*/


### PR DESCRIPTION
Keeping the csv files in the resources directory was untenable. The solution settled upon is to use a third party library to manage the application support directory. This directory varies by OS and the third party is supposed to handle these variations so that a simple API can be made to consistently retrieve the proper directory. The main CSV files will be stored in the `/main` dir and the test CSV files will be stored in the `/test` dir.